### PR TITLE
Part naming versioning and numbering ADRs

### DIFF
--- a/ADL/0005-Part-Numbering-Schema.md
+++ b/ADL/0005-Part-Numbering-Schema.md
@@ -1,0 +1,93 @@
+---
+log: solaris
+index: 5
+title: Part Numbering Schema
+status: proposed
+date: 2025-06-09T10:16:00-05
+decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+consulted: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+informed: [Everyone]
+tags: []
+---
+
+## Context and Problem Statement
+We must standardize part numbering in order to ensure uniformity with regard to referencing parts. These part numbers will be used in file names, git operations, budgeting spreadsheets or just in conversation.
+
+## Decision Drivers
+* Ease of creation: Creating new part numbers, or typing out a part number in general, should be easy and quick.
+* Readability: One should be able to tell what part it is referencing.
+* Uniqueness: Each part number should be unique from any other part that will be created within the club.
+
+## Considered Options
+* Sol-El-1234-5
+
+## Decision Outcome
+Chosen option: "Sol-El-1234-5", because it's the only option right now. Omar and I spent a while trying to determine the best schema, and this is what we landed on.
+
+### Consequences
+* Good, because each part number will be unique. (216 Million combinations)
+* Good, because it allows for up to 36 parts in an assembly without deviating from the schema
+* Good, because part numbers are still very short
+* Good, because part numbers will self-organize when listed alphabetically
+* Neutral, because it must be paired with some sort of description schema if read out-of-context
+* Neutral, because every part must belong to one, and only one, subsystem. This can be viewed as a good or bad thing, depending on if you value the benefits of having distinct responsibilities for each sub-system.
+
+### Confirmation
+Part numbering will be used for all official references to parts and assemblies.
+
+## Pros and Cons of the Options
+### Sol-El-1234-5
+* Good, because each part number will be unique. (216 Million combinations)
+* Good, because it allows for up to 36 parts in an assembly without deviating from the schema
+* Good, because part numbers are still very short
+* Good, because part numbers will self-organize when listed alphabetically
+* Neutral, because it must be paired with some sort of description schema if read out-of-context
+* Neutral, because every part must belong to one, and only one, subsystem. This can be viewed as a good or bad thing, depending on if you value the benefits of having distinct responsibilities for each sub-system.
+
+## More Information
+### Sol-El-1234-5 (AAA-BB-CDEF-G)
+```
+AAA -> Vehicle Name abbriviated --------> Solaris ------------------> Sol
+BB --> Subsystem abbriviated -----------> Electrical ---------------> El
+C ---> Top Level Assembly Identifier ---> Battery ----> 1000 level -> 1 (Arbitrary)
+D ---> Sub-Assembly Identifier ---------> pack -------> 200 level --> 2 (Arbitrary or sequencial)
+E ---> Sub-Sub-Assembly Identifier -----> string -----> String 3 ---> 3 (Arbitrary or sequencial)
+F ---> Sub-Sub-Sub-Assembly Identifier -> module -----> Module 4 ---> 4 (Arbitrary or sequencial)
+G ---> Part Identifier -----------------> cell -------> Cell 5 -----> 5 (Arbitrary or sequencial)
+```
+
+#### AAA -> Vehicle Name abbreviated
+The vehicle's name abbreviated to 3 characters. \
+Ex. Solaris -> Sol
+
+#### BB -> Subsystem abbreviated
+The subsystem the part belongs to abbreviated to 2 characters. \
+Ex. **Ch**assis -> **Ch** \
+Ex. **El**ectrical -> **El** \
+Ex. **Er**gonomics -> **Er** \
+Ex. **V**ehicle **d**ynamics -> **Vd**
+
+#### C -> Top Level Assembly Identifier
+The Top-level assembly the part exists under within the subsystem. \
+1, ... , 8, 9, a, b, ... , y, z \
+Ex. The battery might use the 1000 level identifier, so "1"
+
+#### D -> Sub-Assembly Identifier
+The Sub-Assembly the part exists under within the Top-Level Assembly. \
+1, ... , 8, 9, a, b, ... , y, z \
+Ex. The "pack" might use the 200 level identifier, so "2"
+
+#### E -> Sub-Sub-Assembly Identifier
+The Sub-Sub-Assembly the part exists under within the Sub-Assembly. \
+1, ... , 8, 9, a, b, ... , y, z \
+Ex. One of the strings might use the 30 level identifier, so "3"
+
+#### F -> Sub-Sub-Sub-Assembly Identifier
+The Sub-Sub-Sub-Assembly the part exists under within the Sub-Sub-Assembly. \
+1, ... , 8, 9, a, b, ... , y, z \
+Ex. One of the modules might use the 4 level identifier, so "4"
+
+#### G -> Part Identifier
+The identifier for the part. "0" is a sentinel value that means that the part is an assembly \
+0, 1, ... , 8, 9, a, b, ... , y, z \
+Ex. One of the cells might use the identifier 5

--- a/ADL/0006-Part-Versioning-Schema.md
+++ b/ADL/0006-Part-Versioning-Schema.md
@@ -17,9 +17,9 @@ We must standardize part versioning in order to prevent breaking assemblies.
 ## Decision Drivers
 
 * Ease of creation: Creating new version numbers should be easy and quick.
-* Readability: One should be able to gether usable information from a version number. 
+* Readability: One should be able to gather usable information from a version number. 
 * Uniqueness: Each version number should be unique.
-* Chronological: The version numbers should be in chronological order when sorted alphabetacally.
+* Chronological: The version numbers should be in chronological order when sorted alphabetically.
 
 ## Considered Options
 
@@ -34,10 +34,10 @@ Chosen option: "Semantic Versioning", because It allows version numbers to provi
 
 ### Consequences
 
-* Good, because revisions are classified as compatable or incompatable
+* Good, because revisions are classified as compatible or incompatible
 * Good, because it is a popular way of tracking versions
 * Good, because PATCH level changes don't need to be updated with any urgency
-* Good, because MINOR level changes won't halt development if they aren't imeadiately updated
+* Good, because MINOR level changes won't halt development if they aren't immediately updated
 
 ## Pros and Cons of the Options
 ### Semantic Versioning
@@ -48,14 +48,14 @@ PATCH level changes include those that simply fix existing geometry or make some
 
 MINOR level changes include those that make a significant change to the inner functionality of the part but do not change the way the part interacts with others.
 
-MAJOR level changes include those that make incompatable changes to the part that require others to adapt to.
+MAJOR level changes include those that make incompatible changes to the part that require others to adapt to.
 
 This blog post explains semantic versioning and how it streamlines CAD iteration: https://www.cadtrainingonline.com/5-best-practices-for-cad-version-control/#1_Use_Semantic_Versioning_for_Design_Iterations
 
-* Good, because revisions are classified as compatable or incompatable
+* Good, because revisions are classified as compatible or incompatible
 * Good, because it is a popular way of tracking versions
 * Good, because PATCH level changes don't need to be updated with any urgency
-* Good, because MINOR level changes won't halt development if they aren't imeadiately updated
+* Good, because MINOR level changes won't halt development if they aren't immediately updated
 
 ### Incremental
 Each time a change is made, a singular version number is incremented.
@@ -63,13 +63,13 @@ Each time a change is made, a singular version number is incremented.
 Ex. v1 -> v2 -> v3
 
 * Good, because it is intuitive
-* Bad, because numbers becomes unweildy when part changes are frequent.
+* Bad, because numbers becomes unwieldy when part changes are frequent.
 * Bad, because the new version could be entirely different or have one insignificant adjustment.
 * Bad, because parts must be manually updated in assemblies for every change.
 
 ### Branching Method
 This method relies on different git branches that use the same part name. The version of the part is tied to the git branch it is on.
-* Good, because solidworks would automatically use whatever part is currently checked out in the working directory.
+* Good, because SolidWorks would automatically use whatever part is currently checked out in the working directory.
 * Neutral, because part versions are implied rather than explicit.
 * Bad, because it is fragile
 

--- a/ADL/0006-Part-Versioning-Schema.md
+++ b/ADL/0006-Part-Versioning-Schema.md
@@ -2,7 +2,7 @@
 log: solaris
 index: 6
 title: Part Versioning Schema
-status: draft
+status: proposed
 date: 2025-06-09T01:09:00-05
 decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
 consulted: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]

--- a/ADL/0006-Part-Versioning-Schema.md
+++ b/ADL/0006-Part-Versioning-Schema.md
@@ -1,0 +1,77 @@
+---
+log: solaris
+index: 6
+title: Part Versioning Schema
+status: draft
+date: 2025-06-09T01:09:00-05
+decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+consulted: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+informed: [Everyone]
+tags: []
+---
+
+## Context and Problem Statement
+
+We must standardize part versioning in order to prevent breaking assemblies.
+
+## Decision Drivers
+
+* Ease of creation: Creating new version numbers should be easy and quick.
+* Readability: One should be able to gether usable information from a version number. 
+* Uniqueness: Each version number should be unique.
+* Chronological: The version numbers should be in chronological order when sorted alphabetacally.
+
+## Considered Options
+
+* Semantic Versioning
+* Branching Method
+* Incremental
+* None
+
+## Decision Outcome
+
+Chosen option: "Semantic Versioning", because It allows version numbers to provide critical information about revisions.
+
+### Consequences
+
+* Good, because revisions are classified as compatable or incompatable
+* Good, because it is a popular way of tracking versions
+* Good, because PATCH level changes don't need to be updated with any urgency
+* Good, because MINOR level changes won't halt development if they aren't imeadiately updated
+
+## Pros and Cons of the Options
+### Semantic Versioning
+
+In short, Semantic Versioning consists of a MAJOR version, a MINOR version and a PATCH version. like the following: `MAJOR.MINOR.PATCH`
+
+PATCH level changes include those that simply fix existing geometry or make something work the way it was originally intended to.
+
+MINOR level changes include those that make a significant change to the inner functionality of the part but do not change the way the part interacts with others.
+
+MAJOR level changes include those that make incompatable changes to the part that require others to adapt to.
+
+This blog post explains semantic versioning and how it streamlines CAD iteration: https://www.cadtrainingonline.com/5-best-practices-for-cad-version-control/#1_Use_Semantic_Versioning_for_Design_Iterations
+
+* Good, because revisions are classified as compatable or incompatable
+* Good, because it is a popular way of tracking versions
+* Good, because PATCH level changes don't need to be updated with any urgency
+* Good, because MINOR level changes won't halt development if they aren't imeadiately updated
+
+### Incremental
+Each time a change is made, a singular version number is incremented.
+
+Ex. v1 -> v2 -> v3
+
+* Good, because it is intuitive
+* Bad, because numbers becomes unweildy when part changes are frequent.
+* Bad, because the new version could be entirely different or have one insignificant adjustment.
+* Bad, because parts must be manually updated in assemblies for every change.
+
+### Branching Method
+This method relies on different git branches that use the same part name. The version of the part is tied to the git branch it is on.
+* Good, because solidworks would automatically use whatever part is currently checked out in the working directory.
+* Neutral, because part versions are implied rather than explicit.
+* Bad, because it is fragile
+
+### None
+* Bad, because bad

--- a/ADL/0007-Part-Naming-Schema.md
+++ b/ADL/0007-Part-Naming-Schema.md
@@ -1,0 +1,60 @@
+---
+log: solaris
+index: 7
+title: Part Naming Schema
+status: proposed
+date: 2025-06-09T12:15:00-05
+decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+consulted: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
+informed: [Everyone]
+tags: []
+---
+
+## Context and Problem Statement
+
+We must standardize part naming.
+
+## Decision Drivers
+
+* Ease of creation: Creating new part names, or typing out a part name in general, should be easy and quick.
+* Readability: One should be able to tell what part it is referencing. 
+* Uniqueness: Each part name should be unique from any other part that will be created within the club.
+
+## Considered Options
+
+* {Part Number}-{Part Description}-{Part Version}
+
+## Decision Outcome
+
+Chosen option: "{Part Number}-{Part Description}-{Part Version}", because it satisfies the readability and uniqueness drivers, and it is the only option right now.
+
+### Consequences
+
+* Good, because each part name will be unique as long as part numbers are unique.
+* Good, because part names will self-organize when listed alphabetically
+* Bad, because part names will be long
+
+### Confirmation
+
+Part naming will be used for any official references to parts or assemblies that require descriptive elements. e.g. CAD filenames.
+
+## Pros and Cons of the Options
+
+### {Part Number}-{Abbreviated Part Description}-{Part Version}
+
+This naming schema will use the Part Number and Part Version along with a description of the part to create a filename that is descriptive, unique, and relatively easy to create.
+
+The Abbreviated Part Description will be a list of words that describe the location and functionality of a part, from most general category to most specific category. This description should sound natural when read from RIGHT to left.
+
+General categories:
+```
+assembly --------> ASM
+weldment --------> WLD
+electronics pcb -> PCB
+machined part ---> PRT
+chassis tab -----> TAB
+```
+
+* Good, because each part name will be unique as long as part numbers are unique.
+* Good, because part names will self-organize when listed alphabetically
+* Bad, because part names will be long

--- a/ADL/0007-Part-Naming-Schema.md
+++ b/ADL/0007-Part-Naming-Schema.md
@@ -1,7 +1,7 @@
 ---
 log: solaris
 index: 7
-title: Part File Naming Schema
+title: Part Naming Schema
 status: proposed
 date: 2025-06-10T11:04:00-05
 decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]

--- a/ADL/0007-Part-Naming-Schema.md
+++ b/ADL/0007-Part-Naming-Schema.md
@@ -1,9 +1,9 @@
 ---
 log: solaris
 index: 7
-title: Part Naming Schema
+title: Part File Naming Schema
 status: proposed
-date: 2025-06-09T12:15:00-05
+date: 2025-06-10T11:04:00-05
 decision_makers: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
 consulted: [Technical_Director, Chassis_Lead, Electrical_Lead, Ergonomics_Lead, Vehicle_Dynamics_Lead]
 informed: [Everyone]
@@ -12,39 +12,53 @@ tags: []
 
 ## Context and Problem Statement
 
-We must standardize part naming.
+We must standardize part filenaming.
 
 ## Decision Drivers
 
-* Ease of creation: Creating new part names, or typing out a part name in general, should be easy and quick.
-* Readability: One should be able to tell what part it is referencing. 
-* Uniqueness: Each part name should be unique from any other part that will be created within the club.
+* Ease of creation: Creating new part's filename, or typing out a part filename in general, should be quick and easy.
+* Readability: One should be able to tell what part the filename is referencing. 
+* Uniqueness: Each filename should be unique from any other part that will be created within the club.
 
 ## Considered Options
 
+Subdirectory:
+* /
+* {subsystem directory}/
+* {subsystem directory}/{Part Number}-{Part Description}/
+
+Filename:
 * {Part Number}-{Part Description}-{Part Version}
+* {Part Number}-{Part Version}
 
 ## Decision Outcome
 
-Chosen option: "{Part Number}-{Part Description}-{Part Version}", because it satisfies the readability and uniqueness drivers, and it is the only option right now.
+Chosen option: "Subdirectory: {subsystem directory}/{Part Number}-{Part Description}/  Name: {Part Number}-{Part Version}", because it satisfies the uniqueness driver and the Ease of creation driver.
 
 ### Consequences
 
-* Good, because each part name will be unique as long as part numbers are unique.
-* Good, because part names will self-organize when listed alphabetically
-* Bad, because part names will be long
-
-### Confirmation
-
-Part naming will be used for any official references to parts or assemblies that require descriptive elements. e.g. CAD filenames.
+* Good, because each filename will be unique as long as part numbers and version numbers are unique.
+* Good, because filenames will self-organize when listed alphabetically
+* Good, because filenames will be relatively short
+* Good, because the part's folder name will provide the part description
+* Bad, because part descriptions will only be available via the part's folder name
 
 ## Pros and Cons of the Options
 
-### {Part Number}-{Abbreviated Part Description}-{Part Version}
+### Subdirectory: /
+All versions of a part will be stored in the root directory.
 
-This naming schema will use the Part Number and Part Version along with a description of the part to create a filename that is descriptive, unique, and relatively easy to create.
+* Bad, because unorganized
 
-The Abbreviated Part Description will be a list of words that describe the location and functionality of a part, from most general category to most specific category. This description should sound natural when read from RIGHT to left.
+### Subdirectory: {subsystem directory}/
+All versions of a part will be stored in their subsystem's directory.
+
+* Bad, because there would be way too many version files
+
+### Subdirectory: {subsystem directory}/{Part Number}-{Part Description}/
+All versions of a part will be stored in a subdirectory containing the part number and part description.
+
+The Part Description will be a list of words that describe the location and functionality of a part, from most general category to most specific category. This description should sound natural when read from RIGHT to left.
 
 General categories:
 ```
@@ -55,6 +69,21 @@ machined part ---> PRT
 chassis tab -----> TAB
 ```
 
+* Good, because all versions of a single part will be stored in one folder
+* Good, because the part description
+
+### Filename: {Part Number}-{Part Description}-{Part Version}
+
+This naming schema will use the Part Number and Part Version along with a description of the part to create a filename that is descriptive, unique, and relatively easy to create.
+
 * Good, because each part name will be unique as long as part numbers are unique.
 * Good, because part names will self-organize when listed alphabetically
 * Bad, because part names will be long
+
+### Filename: {Part Number}-{Part Version}
+This naming schema will use the Part Number and Part Version only to create a filename that unique, and easy to create.
+
+* Good, because each part name will be unique as long as part numbers are unique.
+* Good, because part names will self-organize when listed alphabetically
+* Good, because part names will be relatively short
+* Bad, because part descriptions will only be available via the part's folder name


### PR DESCRIPTION
> [!NOTE]
> I combined ADR0006, ADR0007, and ADR0008, into one pull request because they all deal with naming schema for parts.

> [!NOTE]
> "parts" and "assemby" are synonymous in this context unless otherwise stated.

**ADR0005 Part Numbering Schema** proposes a schema we can use to create unique, and organized part numbers that can be used in file names, budgets, etc

**ADR0006 Part Versioning Schema** proposes a schema we can use to define version numbers for parts.

**ADR0007 Part Naming Schema** proposes a schema we can use to create unique, descriptive, organized, and versioned file names.

Brief explanation for the part name:
Sol-El-1234-5_COTS_Battery_Cell / Sol-El-1234-5-v1.0.1.SLDPRT
```
Sol-El-1234-5    COTS Battery Cell    v1.0.1    .SLDPRT
     ^                  ^                ^         ^
     |                  |                |         |
Part number        Description        Version     File extension

Part number: Sol-El-1234-5
             AAA-BB-CDEF-G

AAA -> Vehicle Name abbriviated --------> Solaris ------------------> Sol
BB --> Subsystem abbriviated -----------> Electrical ---------------> El
C ---> Top Level Assembly Identifier ---> Battery ----> 1000 level -> 1 (Arbitrary)
D ---> Sub-Assembly Identifier ---------> pack -------> 200 level --> 2 (Arbitrary or sequencial)
E ---> Sub-Sub-Assembly Identifier -----> string -----> String 3 ---> 3 (Arbitrary or sequencial)
F ---> Sub-Sub-Sub-Assembly Identifier -> module -----> Module 4 ---> 4 (Arbitrary or sequencial)
G ---> Part Identifier -----------------> cell -------> Cell 5 -----> 5 (Arbitrary or sequencial)

Description: COTS Battery Cell

It is a Cell -> Cell
in the battery -> Battery
not made by us -> Commercial off-the-shelf -> COTS

Version number: v1.0.1

Initial model -> v1.0.0 -> fix model -> v1.0.1
```
